### PR TITLE
GitHub Workflows hotfix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,6 @@ repos:
   - id: requirements-txt-fixer
   - id: mixed-line-ending
     args: ['--fix=auto']
-  - id: no-commit-to-branch
-    args: [--branch, main-priv, --branch, main]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0


### PR DESCRIPTION
## Description
Remove `no-commit-branch` item from pre-commit, at it will fail the `test.yml` workflow on merging to main. GitHub repo branch protection already disallows pushing directly to `main` anyway.

## Affected Dependencies
None.

## How has this been tested?
N/A

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
