### PR TITLE
Dataset enhancements

### DIFF
--- a/src/tempor/core/utils.py
+++ b/src/tempor/core/utils.py
@@ -20,3 +20,12 @@ class RichReprStrPassthrough:
 
     def __repr__(self) -> str:
         return self.string
+
+
+def is_iterable(o: object) -> bool:
+    is_iterable_ = True
+    try:
+        iter(o)  # type: ignore[call-overload]
+    except TypeError:
+        is_iterable_ = False
+    return is_iterable_

--- a/src/tempor/data/data_typing.py
+++ b/src/tempor/data/data_typing.py
@@ -1,7 +1,7 @@
 """Types (and related code) for TemporAI data handling."""
 
 import enum
-from typing import Dict, List, Tuple, Type, Union
+from typing import Dict, Iterable, List, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -56,6 +56,9 @@ SampleTimeIndexTuples = List[
     ]
 ]
 TimeIndexList = List[TimeIndex]
+
+
+GetItemKey = Union[int, Iterable[int], slice]
 
 
 class PredictiveTask(enum.Enum):

--- a/src/tempor/data/predictive.py
+++ b/src/tempor/data/predictive.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import rich.pretty
 
@@ -7,26 +7,34 @@ from tempor.core.utils import RichReprStrPassthrough
 
 from . import data_typing, samples
 
+if TYPE_CHECKING:  # pragma: no cover
+    from .dataset import Dataset  # For typing only, no circular import.
+
+
 # TODO: Unit test.
 
 
 class PredictiveTaskData(abc.ABC):
-    targets: samples.DataSamples
-    treatments: Optional[samples.DataSamples]
+    _targets: samples.DataSamples
+    _treatments: Optional[samples.DataSamples]
 
     @property
     @abc.abstractmethod
     def predictive_task(self) -> data_typing.PredictiveTask:  # pragma: no cover
         ...
 
-    @abc.abstractmethod
     def __init__(
         self,
-        targets: Any,
-        treatments: Optional[Any],
-        **kwargs,
+        parent_dataset: "Dataset",
+        targets: Any,  # pylint: disable=unused-argument
+        treatments: Optional[Any],  # pylint: disable=unused-argument
+        **kwargs,  # pylint: disable=unused-argument
     ) -> None:  # pragma: no cover
-        ...
+        self.parent_dataset = parent_dataset
+        # ^ In order to be able to call parent dataset's `validate` method in the targets/treatments property setters.
+
+        self._targets = targets
+        self._treatments = treatments
 
     def __rich_repr__(self):
         yield "targets", RichReprStrPassthrough(self.targets.short_repr())
@@ -35,6 +43,24 @@ class PredictiveTaskData(abc.ABC):
 
     def __repr__(self) -> str:
         return rich.pretty.pretty_repr(self)
+
+    @property
+    def targets(self) -> samples.DataSamples:
+        return self._targets
+
+    @targets.setter
+    def targets(self, value: samples.DataSamples) -> None:
+        self._targets = value
+        self.parent_dataset.validate()
+
+    @property
+    def treatments(self) -> Optional[samples.DataSamples]:
+        return self._treatments
+
+    @treatments.setter
+    def treatments(self, value: Optional[samples.DataSamples]) -> None:
+        self._treatments = value
+        self.parent_dataset.validate()
 
 
 # Predictive task data classes corresponding to different tasks follow. More can be added to handle new tasks.
@@ -52,10 +78,10 @@ class OneOffPredictionTaskData(PredictiveTaskData):
     def predictive_task(self) -> data_typing.PredictiveTask:
         return data_typing.PredictiveTask.ONE_OFF_PREDICTION
 
-    def __init__(self, targets: data_typing.DataContainer, **kwargs) -> None:
-        self.targets = samples.StaticSamples(targets)
-        self.treatments = None
-        super().__init__(targets=targets, treatments=None)
+    def __init__(self, parent_dataset: "Dataset", targets: data_typing.DataContainer, **kwargs) -> None:
+        super().__init__(parent_dataset=parent_dataset, targets=targets, treatments=None)
+        self._targets = samples.StaticSamples(targets)
+        self._treatments = None
 
 
 class TemporalPredictionTaskData(PredictiveTaskData):
@@ -68,10 +94,10 @@ class TemporalPredictionTaskData(PredictiveTaskData):
     def predictive_task(self) -> data_typing.PredictiveTask:
         return data_typing.PredictiveTask.TEMPORAL_PREDICTION
 
-    def __init__(self, targets: data_typing.DataContainer, **kwargs) -> None:
-        self.targets = samples.TimeSeriesSamples(targets)
-        self.treatments = None
-        super().__init__(targets=targets, treatments=None)
+    def __init__(self, parent_dataset: "Dataset", targets: data_typing.DataContainer, **kwargs) -> None:
+        super().__init__(parent_dataset=parent_dataset, targets=targets, treatments=None)
+        self._targets = samples.TimeSeriesSamples(targets)
+        self._treatments = None
 
 
 # --- Time-to-event tasks: ---
@@ -87,10 +113,10 @@ class TimeToEventAnalysisTaskData(PredictiveTaskData):
     def predictive_task(self) -> data_typing.PredictiveTask:
         return data_typing.PredictiveTask.TIME_TO_EVENT_ANALYSIS
 
-    def __init__(self, targets: data_typing.DataContainer, **kwargs) -> None:
-        self.targets = samples.EventSamples(targets)
-        self.treatments = None
-        super().__init__(targets=targets, treatments=None)
+    def __init__(self, parent_dataset: "Dataset", targets: data_typing.DataContainer, **kwargs) -> None:
+        super().__init__(parent_dataset=parent_dataset, targets=targets, treatments=None)
+        self._targets = samples.EventSamples(targets)
+        self._treatments = None
 
 
 # --- Treatment Effects tasks: ---
@@ -106,10 +132,16 @@ class OneOffTreatmentEffectsTaskData(PredictiveTaskData):
     def predictive_task(self) -> data_typing.PredictiveTask:
         return data_typing.PredictiveTask.TEMPORAL_TREATMENT_EFFECTS
 
-    def __init__(self, targets: data_typing.DataContainer, treatments: data_typing.DataContainer, **kwargs) -> None:
-        self.targets = samples.TimeSeriesSamples(targets)
-        self.treatments = samples.EventSamples(treatments)
-        super().__init__(targets=targets, treatments=treatments)
+    def __init__(
+        self,
+        parent_dataset: "Dataset",
+        targets: data_typing.DataContainer,
+        treatments: data_typing.DataContainer,
+        **kwargs,
+    ) -> None:
+        super().__init__(parent_dataset=parent_dataset, targets=targets, treatments=treatments)
+        self._targets = samples.TimeSeriesSamples(targets)
+        self._treatments = samples.EventSamples(treatments)
 
 
 class TemporalTreatmentEffectsTaskData(PredictiveTaskData):
@@ -122,7 +154,13 @@ class TemporalTreatmentEffectsTaskData(PredictiveTaskData):
     def predictive_task(self) -> data_typing.PredictiveTask:
         return data_typing.PredictiveTask.TEMPORAL_TREATMENT_EFFECTS
 
-    def __init__(self, targets: data_typing.DataContainer, treatments: data_typing.DataContainer, **kwargs) -> None:
-        self.targets = samples.TimeSeriesSamples(targets)
-        self.treatments = samples.TimeSeriesSamples(treatments)
-        super().__init__(targets=targets, treatments=treatments)
+    def __init__(
+        self,
+        parent_dataset: "Dataset",
+        targets: data_typing.DataContainer,
+        treatments: data_typing.DataContainer,
+        **kwargs,
+    ) -> None:
+        super().__init__(parent_dataset=parent_dataset, targets=targets, treatments=treatments)
+        self._targets = samples.TimeSeriesSamples(targets)
+        self._treatments = samples.TimeSeriesSamples(treatments)

--- a/src/tempor/data/utils.py
+++ b/src/tempor/data/utils.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 import pydantic
 
+import tempor.core.utils
+
 from . import data_typing
 
 
@@ -287,3 +289,16 @@ def array3d_to_multiindex_timeseries_dataframe(
         index=pd.MultiIndex.from_tuples(make_sample_time_index_tuples(sample_index, time_indexes)),
         columns=feature_index,
     )
+
+
+# --- Miscellaneous. ---
+
+
+def ensure_pd_iloc_key_returns_df(key):
+    if isinstance(key, slice):
+        key_: Any = key
+    elif tempor.core.utils.is_iterable(key):
+        key_ = key
+    else:
+        key_ = [key]
+    return key_

--- a/src/tempor/utils/datasets/google_stocks.py
+++ b/src/tempor/utils/datasets/google_stocks.py
@@ -66,6 +66,9 @@ class GoogleStocksDataloader:
         outcome_df.index = sample_idxs  # pyright: ignore
         outcome_df.columns = ["out"]
 
+        time_series_df.sort_index(level=[0, 1], inplace=True)
+        outcome_df.sort_index(inplace=True)
+
         return OneOffPredictionDataset(
             time_series=time_series_df,
             targets=outcome_df,

--- a/src/tempor/utils/datasets/sine.py
+++ b/src/tempor/utils/datasets/sine.py
@@ -96,6 +96,10 @@ class SineDataloader:
         time_series_df = pd.concat(temporal_data, ignore_index=True)
         time_series_df.set_index(keys=["sample_idx", "time_idx"], drop=True, inplace=True)
 
+        time_series_df.sort_index(level=[0, 1], inplace=True)
+        static_data.sort_index(inplace=True)
+        outcome.sort_index(inplace=True)
+
         return OneOffPredictionDataset(
             time_series=time_series_df,
             targets=outcome,

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -72,7 +72,6 @@ def test_change_config_via_hydra(tmp_path_factory, mock_updated_on_configure):
     # https://hydra.cc/docs/advanced/compose_api/
     with initialize_config_dir(version_base=None, config_dir=str(user_config_dir)):
         user_config = compose(config_name=user_config_name)
-        print(OmegaConf.to_yaml(user_config))
         lib_config = tempor.configure(user_config.tempor)
         assert isinstance(lib_config, TemporConfig)
         assert lib_config.logging.level == "VALUE_SET_VIA_HYDRA"

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1100,3 +1100,71 @@ class TestWithConcreteData:
             targets=target,
             treatments=treatment,
         )
+
+    @pytest.mark.parametrize(
+        "time_series, static, target, treatment",
+        [
+            (
+                test_dfs.df_time_series.copy(),
+                test_dfs.df_static.copy(),
+                test_dfs.df_time_series.copy(),
+                test_dfs.df_time_series.copy(),
+            ),
+            (
+                test_dfs.df_time_series.copy(),
+                None,
+                test_dfs.df_time_series.copy(),
+                test_dfs.df_time_series.copy(),
+            ),
+        ],
+    )
+    def test_init_temporal_treatment_effects_dataset(self, time_series, static, target, treatment):
+        dataset.TemporalTreatmentEffectsDataset(
+            time_series=time_series,
+            static=static,
+            targets=target,
+            treatments=treatment,
+        )
+
+    def test_set_properties(self):
+        data = dataset.TemporalTreatmentEffectsDataset(
+            time_series=test_dfs.df_time_series.copy(),
+            static=test_dfs.df_static.copy(),
+            targets=test_dfs.df_time_series.copy(),
+            treatments=test_dfs.df_time_series.copy(),
+        )
+
+        df_s = pd.DataFrame(
+            {
+                "sample_idx": ["sample_1", "sample_2", "sample_3"],
+                "feat_new": [101, 201, 301],
+            }
+        )
+        df_s.set_index("sample_idx", drop=True, inplace=True)
+
+        df_t = pd.DataFrame(
+            {
+                "sample_idx": ["sample_1", "sample_1", "sample_1", "sample_1", "sample_2", "sample_2", "sample_3"],
+                "time_idx": [
+                    pd.to_datetime("2000-01-01"),
+                    pd.to_datetime("2000-01-02"),
+                    pd.to_datetime("2000-01-03"),
+                    pd.to_datetime("2000-01-04"),
+                    pd.to_datetime("2000-02-01"),
+                    pd.to_datetime("2000-02-02"),
+                    pd.to_datetime("2000-03-01"),
+                ],
+                "feat_new": [11, 12, 13, 14, 21, 22, 31],
+            }
+        )
+        df_t.set_index(keys=["sample_idx", "time_idx"], drop=True, inplace=True)
+
+        data.static = samples.StaticSamples(df_s)
+        data.time_series = samples.TimeSeriesSamples(df_t)
+        data.predictive.targets = samples.TimeSeriesSamples(df_t)
+        data.predictive.treatments = samples.TimeSeriesSamples(df_t)
+
+        assert data.static.dataframe().equals(df_s)
+        assert data.time_series.dataframe().equals(df_t)
+        assert data.predictive.targets.dataframe().equals(df_t)
+        assert data.predictive.treatments.dataframe().equals(df_t)

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -288,7 +288,9 @@ class TestOneOffPredictionDataset:
 
         mocked_depends.TimeSeriesSamples.assert_called_once_with(data_time_series)
         mocked_depends.StaticSamples.assert_called_once_with(data_static)
-        mocked_depends.OneOffPredictionTaskData.assert_called_once_with(targets=data_targets, dummy="kwarg")
+        mocked_depends.OneOffPredictionTaskData.assert_called_once_with(
+            parent_dataset=dummy_dataset, targets=data_targets, dummy="kwarg"
+        )
         dummy_dataset.mock_validate_call.assert_called_once()
 
     def test_validate_passes(
@@ -385,7 +387,9 @@ class TestTemporalPredictionDataset:
 
         mocked_depends.TimeSeriesSamples.assert_called_once_with(data_time_series)
         mocked_depends.StaticSamples.assert_called_once_with(data_static)
-        mocked_depends.TemporalPredictionTaskData.assert_called_once_with(targets=data_targets, dummy="kwarg")
+        mocked_depends.TemporalPredictionTaskData.assert_called_once_with(
+            parent_dataset=dummy_dataset, targets=data_targets, dummy="kwarg"
+        )
         dummy_dataset.mock_validate_call.assert_called_once()
 
     def test_validate_passes(
@@ -519,7 +523,9 @@ class TestTimeToEventAnalysisDataset:
 
         mocked_depends.TimeSeriesSamples.assert_called_once_with(data_time_series)
         mocked_depends.StaticSamples.assert_called_once_with(data_static)
-        mocked_depends.TimeToEventAnalysisTaskData.assert_called_once_with(targets=data_targets, dummy="kwarg")
+        mocked_depends.TimeToEventAnalysisTaskData.assert_called_once_with(
+            parent_dataset=dummy_dataset, targets=data_targets, dummy="kwarg"
+        )
         dummy_dataset.mock_validate_call.assert_called_once()
 
     def test_validate_passes(
@@ -621,7 +627,7 @@ class TestOneOffTreatmentEffectsDataset:
         mocked_depends.TimeSeriesSamples.assert_called_once_with(data_time_series)
         mocked_depends.StaticSamples.assert_called_once_with(data_static)
         mocked_depends.OneOffTreatmentEffectsTaskData.assert_called_once_with(
-            targets=data_targets, treatments=data_treatments, dummy="kwarg"
+            parent_dataset=dummy_dataset, targets=data_targets, treatments=data_treatments, dummy="kwarg"
         )
         dummy_dataset.mock_validate_call.assert_called_once()
 
@@ -800,7 +806,7 @@ class TestTemporalTreatmentEffectsDataset:
         mocked_depends.TimeSeriesSamples.assert_called_once_with(data_time_series)
         mocked_depends.StaticSamples.assert_called_once_with(data_static)
         mocked_depends.TemporalTreatmentEffectsTaskData.assert_called_once_with(
-            targets=data_targets, treatments=data_treatments, dummy="kwarg"
+            parent_dataset=dummy_dataset, targets=data_targets, treatments=data_treatments, dummy="kwarg"
         )
         dummy_dataset.mock_validate_call.assert_called_once()
 

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -823,8 +823,6 @@ class TestArray3dToMultiindexTimeseriesDataframe:
         )
 
         mock_validate_timeseries_array3d.assert_called()
-        print(df)
-        print(expected)
         assert df.equals(expected)
 
     @pytest.mark.parametrize(

--- a/tests/models/test_mlp.py
+++ b/tests/models/test_mlp.py
@@ -151,4 +151,3 @@ def test_mlp_regression(residual: bool) -> None:
     assert model.predict(X).shape == y.shape
     with pytest.raises(ValueError):
         model.predict_proba(X)
-    print(model.score(X, y))

--- a/tests/models/test_ts_model.py
+++ b/tests/models/test_ts_model.py
@@ -117,5 +117,4 @@ def test_rnn_classification_fit_predict(mode: TSModelMode, source: Any) -> None:
 
     assert y_pred.shape == y.shape
 
-    print(mode, model.score(static_data, temporal_data, observation_times, y))
     assert model.score(static_data, temporal_data, observation_times, y) <= 1


### PR DESCRIPTION
## Description
Closes #35

- Add [`test_train_split`](https://github.com/vanderschaarlab/temporai/compare/DrShushen/DataSet-enhancements?expand=1#diff-bc02d3399d6a01bca9b6e519950984d616a50588ef22372c90cf54d21fa6e3c2R189) to `Dataset`.
- Add [`split`](https://github.com/vanderschaarlab/temporai/compare/DrShushen/DataSet-enhancements?expand=1#diff-bc02d3399d6a01bca9b6e519950984d616a50588ef22372c90cf54d21fa6e3c2R217), which can take `sklearn` cross-validators (like `KFold` or `StratifiedKFold`), to `Dataset`.
- Other minor improvements to `Dataset`.

## Affected Dependencies
None.

## How has this been tested?
- Tested [here](https://github.com/vanderschaarlab/temporai/compare/DrShushen/DataSet-enhancements?expand=1#diff-b33f3ef167803916dc74b5d21cfda3e39fdea75034a356c6f213f92b01d04616R1208) and [here](https://github.com/vanderschaarlab/temporai/compare/DrShushen/DataSet-enhancements?expand=1#diff-b33f3ef167803916dc74b5d21cfda3e39fdea75034a356c6f213f92b01d04616R1219).

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
