### PR TITLE
Add one-hot encoders for static and time series data

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,20 @@ Prediction where targets are temporal (time series).
 
 ### Preprocessing
 
+#### Feature Encoding
+
+* Static data (category: `preprocessing.encoding.static`)
+
+| Name | Description| Reference |
+| --- | --- | --- |
+| `static_onehot_encoder` | One-hot encode categorical static features | --- |
+
+* Temporal data (category: `preprocessing.encoding.temporal`)
+
+| Name | Description| Reference |
+| --- | --- | --- |
+| `ts_onehot_encoder` | One-hot encode categorical time series features | --- |
+
 #### Imputation
 
 * Static data (category: `preprocessing.imputation.static`)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -427,8 +427,8 @@ from tempor.utils.dataloaders import SineDataLoader
 
 dataset = SineDataLoader().load()
 
-# Specify the AutoML pipeline seeker for the task of your choice, providing candidate methods, metric,
-# preprocessing steps etc.
+# Specify the AutoML pipeline seeker for the task of your choice, providing candidate methods,
+# metric, preprocessing steps etc.
 seeker = PipelineSeeker(
     study_name="my_automl_study",
     task_type="prediction.one_off.classification",
@@ -457,8 +457,8 @@ from tempor.utils.dataloaders import SineDataLoader
 
 dataset = SineDataLoader().load()
 
-# Specify the AutoML pipeline seeker for the task of your choice, providing candidate methods, metric,
-# preprocessing steps etc.
+# Specify the AutoML pipeline seeker for the task of your choice, providing candidate methods,
+# metric, preprocessing steps etc.
 seeker = PipelineSeeker(
     study_name="my_automl_study",
     task_type="prediction.one_off.classification",
@@ -575,6 +575,20 @@ Prediction where targets are temporal (time series).
 
 ### Preprocessing
 
+#### Feature Encoding
+
+* Static data (category: `preprocessing.encoding.static`)
+
+| Name | Description| Reference |
+| --- | --- | --- |
+| `static_onehot_encoder` | One-hot encode categorical static features | --- |
+
+* Temporal data (category: `preprocessing.encoding.temporal`)
+
+| Name | Description| Reference |
+| --- | --- | --- |
+| `ts_onehot_encoder` | One-hot encode categorical time series features | --- |
+
 #### Imputation
 
 * Static data (category: `preprocessing.imputation.static`)
@@ -620,15 +634,15 @@ Prediction where targets are temporal (time series).
 - [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/data/tutorial04_data_splitting.ipynb) - [Data Splitting](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/data/tutorial04_data_splitting.ipynb)
 
 ### User Guide
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial01_plugins.ipynb) - [Plugins](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial01_plugins.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial02_imputation.ipynb) - [Imputation](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial02_imputation.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial03_scaling.ipynb) - [Scaling](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial03_scaling.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial04_prediction.ipynb) - [Prediction](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial04_prediction.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial05_time_to_event.ipynb) - [Time-to-event Analysis](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial05_time_to_event.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial06_treatments.ipynb) - [Treatment Effects](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial06_treatments.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial07_pipeline.ipynb) - [Pipeline](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial07_pipeline.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial08_benchmarks.ipynb) - [Benchmarks](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial08_benchmarks.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial09_automl.ipynb) - [AutoML](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial09_automl.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial01_plugins.ipynb) - [Plugins](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial01_plugins.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial02_imputation.ipynb) - [Imputation](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial02_imputation.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial03_scaling.ipynb) - [Scaling](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial03_scaling.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial04_prediction.ipynb) - [Prediction](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial04_prediction.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial05_time_to_event.ipynb) - [Time-to-event Analysis](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial05_time_to_event.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial06_treatments.ipynb) - [Treatment Effects](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial06_treatments.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial07_pipeline.ipynb) - [Pipeline](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial07_pipeline.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial08_benchmarks.ipynb) - [Benchmarks](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial08_benchmarks.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial09_automl.ipynb) - [AutoML](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial09_automl.ipynb)
 
 ### Extending TemporAI
 - [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/extending/tutorial01_custom_plugin.ipynb) - [Writing a Custom Plugin](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/extending/tutorial01_custom_plugin.ipynb)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,13 +2,13 @@
 # under `install_requires` in `setup.cfg` is also listed here!
 # ----- auto_update -----
 # install_requires:
-catboost < 1.2
 clairvoyance2 >=0.0.2
 cloudpickle
 geomloss>=0.2.6
 hydra-core >=1.3
 hyperimpute >= 0.1.17
 importlib-metadata; python_version<"3.8"
+joblib < 1.3.0; python_version=="3.7" and platform_system=="Windows"
 lifelines != 0.27.5
 loguru
 numpy >=1
@@ -26,7 +26,7 @@ torchcde
 torchdiffeq
 torchlaplace >= 0.0.4
 tsai
-typing-extensions
+typing-extensions >= 4.7.1
 xgbse
 # dev:
 black[jupyter]

--- a/docs/user_guide/usage/tutorial01_plugins.md
+++ b/docs/user_guide/usage/tutorial01_plugins.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 01: Plugins
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial01_plugins.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial01_plugins.ipynb)
 
 This tutorial shows how to load TemporAI estimators (a.k.a. models), which are `Plugin`s.
 

--- a/docs/user_guide/usage/tutorial02_imputation.md
+++ b/docs/user_guide/usage/tutorial02_imputation.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 02: Preprocessing › Imputation
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial02_imputation.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial02_imputation.ipynb)
 
 This tutorial shows how to use TemporAI `preprocessing.imputation` plugins.
 

--- a/docs/user_guide/usage/tutorial03_scaling.md
+++ b/docs/user_guide/usage/tutorial03_scaling.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 03: Preprocessing › Scaling
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial03_scaling.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial03_scaling.ipynb)
 
 This tutorial shows how to use TemporAI `preprocessing.scaling` plugins.
 

--- a/docs/user_guide/usage/tutorial04_prediction.md
+++ b/docs/user_guide/usage/tutorial04_prediction.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 04: Prediction
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial04_prediction.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial04_prediction.ipynb)
 
 This tutorial shows how to use TemporAI `prediction` plugins.
 

--- a/docs/user_guide/usage/tutorial05_time_to_event.md
+++ b/docs/user_guide/usage/tutorial05_time_to_event.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 05: Time-to-event Analysis
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial05_time_to_event.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial05_time_to_event.ipynb)
 
 This tutorial shows how to use TemporAI `time_to_event` plugins.
 

--- a/docs/user_guide/usage/tutorial06_treatments.md
+++ b/docs/user_guide/usage/tutorial06_treatments.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 06: Treatment Effects
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial06_treatments.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial06_treatments.ipynb)
 
 This tutorial shows how to use TemporAI `treatments` plugins.
 

--- a/docs/user_guide/usage/tutorial07_pipeline.md
+++ b/docs/user_guide/usage/tutorial07_pipeline.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 07: Pipeline
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial07_pipeline.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial07_pipeline.ipynb)
 
 This tutorial shows how to use TemporAI `Pipeline`s.
 

--- a/docs/user_guide/usage/tutorial08_benchmarks.md
+++ b/docs/user_guide/usage/tutorial08_benchmarks.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 09: Benchmarks
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial08_benchmarks.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial08_benchmarks.ipynb)
 
 TemporAI provides some useful benchmarking tools in `tempor.benchmarks`, these are demonstrated here.
 

--- a/docs/user_guide/usage/tutorial09_automl.md
+++ b/docs/user_guide/usage/tutorial09_automl.md
@@ -1,5 +1,5 @@
 # User Guide Tutorial 09: AutoML
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial09_automl.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial09_automl.ipynb)
 
 TemporAI provides AutoML tools for finding the best model for your use case in `tempor.automl`, these are demonstrated here.
 

--- a/pypi.md
+++ b/pypi.md
@@ -6,7 +6,7 @@
 -->
 
 <!-- exclude_docs -->
-[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial04_prediction.ipynb)
+[![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial04_prediction.ipynb)
 [![Documentation Status](https://readthedocs.org/projects/temporai/badge/?version=latest)](https://temporai.readthedocs.io/en/latest/?badge=latest)
 
 [![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/release/python-370/)
@@ -260,8 +260,8 @@ from tempor.utils.dataloaders import SineDataLoader
 
 dataset = SineDataLoader().load()
 
-# Specify the AutoML pipeline seeker for the task of your choice, providing candidate methods, metric,
-# preprocessing steps etc.
+# Specify the AutoML pipeline seeker for the task of your choice, providing candidate methods,
+# metric, preprocessing steps etc.
 seeker = PipelineSeeker(
     study_name="my_automl_study",
     task_type="prediction.one_off.classification",
@@ -378,6 +378,20 @@ Prediction where targets are temporal (time series).
 
 ### Preprocessing
 
+#### Feature Encoding
+
+* Static data (category: `preprocessing.encoding.static`)
+
+| Name | Description| Reference |
+| --- | --- | --- |
+| `static_onehot_encoder` | One-hot encode categorical static features | --- |
+
+* Temporal data (category: `preprocessing.encoding.temporal`)
+
+| Name | Description| Reference |
+| --- | --- | --- |
+| `ts_onehot_encoder` | One-hot encode categorical time series features | --- |
+
 #### Imputation
 
 * Static data (category: `preprocessing.imputation.static`)
@@ -423,15 +437,15 @@ Prediction where targets are temporal (time series).
 - [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/data/tutorial04_data_splitting.ipynb) - [Data Splitting](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/data/tutorial04_data_splitting.ipynb)
 
 ### User Guide
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial01_plugins.ipynb) - [Plugins](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial01_plugins.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial02_imputation.ipynb) - [Imputation](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial02_imputation.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial03_scaling.ipynb) - [Scaling](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial03_scaling.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial04_prediction.ipynb) - [Prediction](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial04_prediction.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial05_time_to_event.ipynb) - [Time-to-event Analysis](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial05_time_to_event.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial06_treatments.ipynb) - [Treatment Effects](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial06_treatments.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial07_pipeline.ipynb) - [Pipeline](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial07_pipeline.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial08_benchmarks.ipynb) - [Benchmarks](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial08_benchmarks.ipynb)
-- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/user_guide/tutorial09_automl.ipynb) - [AutoML](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/user_guide/tutorial09_automl.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial01_plugins.ipynb) - [Plugins](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial01_plugins.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial02_imputation.ipynb) - [Imputation](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial02_imputation.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial03_scaling.ipynb) - [Scaling](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial03_scaling.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial04_prediction.ipynb) - [Prediction](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial04_prediction.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial05_time_to_event.ipynb) - [Time-to-event Analysis](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial05_time_to_event.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial06_treatments.ipynb) - [Treatment Effects](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial06_treatments.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial07_pipeline.ipynb) - [Pipeline](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial07_pipeline.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial08_benchmarks.ipynb) - [Benchmarks](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial08_benchmarks.ipynb)
+- [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/usage/tutorial09_automl.ipynb) - [AutoML](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/usage/tutorial09_automl.ipynb)
 
 ### Extending TemporAI
 - [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/vanderschaarlab/temporai/blob/main/tutorials/extending/tutorial01_custom_plugin.ipynb) - [Writing a Custom Plugin](https://github.com/vanderschaarlab/temporai/tree/main/tutorials/extending/tutorial01_custom_plugin.ipynb)

--- a/src/tempor/models/ddh.py
+++ b/src/tempor/models/ddh.py
@@ -131,12 +131,15 @@ class DynamicDeepHitModel:
         t: np.ndarray,
         e: np.ndarray,
     ) -> Self:
+        print("e", e)
         discretized_t, self.split_time = self.discretize(t, self.split, self.split_time)
         processed_data = self._preprocess_training_data(x, discretized_t, e)
         x_train, t_train, e_train, x_val, t_val, e_val = processed_data
         inputdim = x_train.shape[-1]
         seqlen = x_train.shape[-2]
 
+        print("e_train", e_train)
+        print("e_val", e_val)
         maxrisk = int(np.nanmax(e_train.cpu().numpy()))
 
         self.model = self._setup_model(inputdim, seqlen, risks=maxrisk)

--- a/src/tempor/plugins/preprocessing/__init__.py
+++ b/src/tempor/plugins/preprocessing/__init__.py
@@ -1,6 +1,7 @@
-from . import imputation, nop, scaling
+from . import encoding, imputation, nop, scaling
 
 __all__ = [
+    "encoding",
     "imputation",
     "nop",
     "scaling",

--- a/src/tempor/plugins/preprocessing/encoding/__init__.py
+++ b/src/tempor/plugins/preprocessing/encoding/__init__.py
@@ -1,0 +1,11 @@
+"""A module that contains methods for encoding data features, such as one-hot encoding.
+"""
+
+from . import static, temporal
+from ._base import BaseEncoder
+
+__all__ = [
+    "BaseEncoder",
+    "static",
+    "temporal",
+]

--- a/src/tempor/plugins/preprocessing/encoding/_base.py
+++ b/src/tempor/plugins/preprocessing/encoding/_base.py
@@ -1,0 +1,6 @@
+import tempor.plugins.core as plugins
+
+
+class BaseEncoder(plugins.BaseTransformer):
+    def __init__(self, **params) -> None:  # pylint: disable=useless-super-delegation
+        super().__init__(**params)

--- a/src/tempor/plugins/preprocessing/encoding/static/__init__.py
+++ b/src/tempor/plugins/preprocessing/encoding/static/__init__.py
@@ -1,0 +1,11 @@
+import tempor.plugins.core as plugins
+
+from .._base import BaseEncoder
+
+plugins.register_plugin_category("preprocessing.encoding.static", BaseEncoder)
+
+plugins.importing.import_plugins(__file__)
+
+__all__ = [
+    *plugins.importing.gather_modules_names(__file__),
+]

--- a/src/tempor/plugins/preprocessing/encoding/static/plugin_static_onehot_encoder.py
+++ b/src/tempor/plugins/preprocessing/encoding/static/plugin_static_onehot_encoder.py
@@ -1,0 +1,153 @@
+import dataclasses
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+import pandas as pd
+import sklearn
+from packaging.version import Version
+from sklearn.preprocessing import OneHotEncoder
+from typing_extensions import Literal, Self
+
+import tempor.plugins.core as plugins
+from tempor.data import dataset
+from tempor.data.data_typing import FeatureIndex
+from tempor.data.samples import StaticSamples
+from tempor.plugins.core._params import CategoricalParams, FloatParams
+from tempor.plugins.preprocessing.encoding._base import BaseEncoder
+
+# TODO: Handle SklearnArrayLike rather than just list, requires dropping OmegaConf stuff.
+# TODO: Remember the column positions - esp. relevant for when inverse_transform is introduced.
+
+
+@dataclasses.dataclass
+class StaticOneHotEncoderParams:
+    """Initialization parameters for :class:`StaticOneHotEncoder`.
+
+    See `sklearn.preprocessing.OneHotEncoder`.
+
+    Note:
+        ``sparse_output`` is always set to ``False``.
+    """
+
+    features: Optional[FeatureIndex] = None
+    """Features to encode. If ``None``, all features will be encoded."""
+    categories: Union[Literal["auto"], List] = "auto"
+    """See ``categories`` in `sklearn.preprocessing.OneHotEncoder`"""
+    drop: Union[None, Literal["first", "if_binary"], List] = None
+    """See ``drop`` in `sklearn.preprocessing.OneHotEncoder`"""
+    dtype: Type = float
+    """See ``dtype`` in `sklearn.preprocessing.OneHotEncoder`"""
+    handle_unknown: Literal["error", "ignore", "infrequent_if_exist"] = "error"
+    """See ``handle_unknown`` in `sklearn.preprocessing.OneHotEncoder`"""
+    min_frequency: Union[int, float, None] = None
+    """See ``min_frequency`` in `sklearn.preprocessing.OneHotEncoder`"""
+    max_categories: Union[int, None] = None
+    """See ``max_categories`` in `sklearn.preprocessing.OneHotEncoder`"""
+    feature_name_combiner: Union[Literal["concat"], Callable] = "concat"
+    """See ``feature_name_combiner`` in `sklearn.preprocessing.OneHotEncoder`"""
+
+
+@plugins.register_plugin(name="static_onehot_encoder", category="preprocessing.encoding.static")
+class StaticOneHotEncoder(BaseEncoder):
+    ParamsDefinition = StaticOneHotEncoderParams
+    params: StaticOneHotEncoderParams  # type: ignore
+
+    def __init__(self, **params) -> None:
+        """One-hot encoding for the static data.
+
+        See `sklearn.preprocessing.OneHotEncoder` for details.
+
+        Specify ``features`` list to encode only a subset of the features.
+
+        Args:
+            **params:
+                Parameters and defaults as defined in :class:`StaticOneHotEncoderParams`.
+
+        Example:
+            >>> from tempor.utils.dataloaders import DummyTemporalPredictionDataLoader
+            >>> from tempor.plugins import plugin_loader
+            >>>
+            >>> dataset = DummyTemporalPredictionDataLoader().load()
+            >>>
+            >>> # Get static data with some categorical features.
+            >>> import numpy as np
+            >>> import pandas as pd
+            >>> from tempor.data.samples import StaticSamples
+            >>> static_df = dataset.static.dataframe()
+            >>> static_df["categorical_feat_1"] = pd.Categorical(
+            ...     np.random.choice(["a", "b", "c"], size=(len(static_df),))
+            ... )
+            >>> static_df["categorical_feat_2"] = pd.Categorical(np.random.choice(["D", "E"], size=(len(static_df),)))
+            >>> dataset.static = StaticSamples.from_dataframe(static_df)
+            >>>
+            >>> # Load the encoder:
+            >>> enc = plugin_loader.get(
+            ...     "preprocessing.encoding.static.static_onehot_encoder",
+            ...     features=["categorical_feat_1", "categorical_feat_2"],
+            ... )
+            >>>
+            >>> # Fit:
+            >>> enc.fit(dataset)
+            StaticOneHotEncoder(...)
+            >>>
+            >>> # Encode:
+            >>> encoded = enc.transform(dataset)
+        """
+        super().__init__(**params)
+        self.features = self.params.features
+        sklearn_params: Dict[str, Any] = {k: v for k, v in dict(self.params).items() if k != "features"}  # type: ignore
+        sklearn_params["sparse_output"] = False
+
+        if Version(sklearn.__version__) < Version("1.3"):  # pragma: no cover
+            del sklearn_params["feature_name_combiner"]
+        if Version(sklearn.__version__) < Version("1.1"):  # pragma: no cover
+            del sklearn_params["min_frequency"]
+            del sklearn_params["max_categories"]
+        if Version(sklearn.__version__) < Version("1.2"):  # pragma: no cover
+            sklearn_params["sparse"] = sklearn_params["sparse_output"]
+            del sklearn_params["sparse_output"]
+
+        self.model = OneHotEncoder(**sklearn_params)
+
+    def _fit(
+        self,
+        data: dataset.BaseDataset,
+        *args,
+        **kwargs,
+    ) -> Self:
+        if data.static is None:
+            return self
+
+        df_to_use = data.static.dataframe()
+        if self.features is None:
+            self.features = df_to_use.columns.tolist()
+        df_to_use = df_to_use[self.features]
+
+        self.model.fit(df_to_use)
+        return self
+
+    def _transform(self, data: dataset.BaseDataset, *args, **kwargs) -> dataset.BaseDataset:
+        if data.static is None:
+            return data
+
+        df_to_encode = data.static.dataframe()[self.features]
+        encoded_arr = self.model.transform(df_to_encode)
+        encoded_col_names = self.model.get_feature_names_out()
+
+        # Drop old columns.
+        original_df = data.static.dataframe().drop(columns=self.features)
+
+        # Append new encoded columns.
+        encoded_df = pd.DataFrame(encoded_arr, columns=encoded_col_names)
+        final_df = pd.concat([original_df, encoded_df], axis=1)
+
+        data.static = StaticSamples.from_dataframe(final_df)
+
+        return data
+
+    @staticmethod
+    def hyperparameter_space(*args, **kwargs):
+        return [
+            CategoricalParams("drop", ["first", "if_binary"]),
+            CategoricalParams("handle_unknown", ["error", "ignore", "infrequent_if_exist"]),
+            FloatParams("min_frequency", 0.0, 0.5),
+        ]

--- a/src/tempor/plugins/preprocessing/encoding/static/plugin_static_onehot_encoder.py
+++ b/src/tempor/plugins/preprocessing/encoding/static/plugin_static_onehot_encoder.py
@@ -16,6 +16,7 @@ from tempor.plugins.preprocessing.encoding._base import BaseEncoder
 
 # TODO: Handle SklearnArrayLike rather than just list, requires dropping OmegaConf stuff.
 # TODO: Remember the column positions - esp. relevant for when inverse_transform is introduced.
+# TODO: Possibly a way to automatically detect categorical features and encode those.
 
 
 @dataclasses.dataclass

--- a/src/tempor/plugins/preprocessing/encoding/temporal/__init__.py
+++ b/src/tempor/plugins/preprocessing/encoding/temporal/__init__.py
@@ -1,0 +1,11 @@
+import tempor.plugins.core as plugins
+
+from .._base import BaseEncoder
+
+plugins.register_plugin_category("preprocessing.encoding.temporal", BaseEncoder)
+
+plugins.importing.import_plugins(__file__)
+
+__all__ = [
+    *plugins.importing.gather_modules_names(__file__),
+]

--- a/tests/plugins/preprocessing/encoding/conftest.py
+++ b/tests/plugins/preprocessing/encoding/conftest.py
@@ -1,0 +1,59 @@
+import copy
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tempor.data import dataset, samples
+from tempor.utils import dataloaders
+
+# --- Reusable datasets. ---
+
+
+# Dummy data: full, with categoricals.
+@pytest.fixture(scope="session")
+def _dummy_data_with_categorical_features_full() -> dataset.OneOffPredictionDataset:
+    data = dataloaders.DummyTemporalPredictionDataLoader(
+        static_covariates_missing_prob=0.0,
+        temporal_covariates_missing_prob=0.0,
+        random_state=777,
+    ).load()
+
+    # Add static categorical features.
+    static_df = data.static.dataframe()
+    np.random.seed(777)
+    cat1 = pd.Categorical(np.random.choice(["a", "b", "c"], size=(len(static_df),)))
+    cat2 = pd.Categorical(np.random.choice(["D", "E"], size=(len(static_df),)))
+    static_df.insert(1, "categorical_feat_1", cat1)
+    static_df["categorical_feat_2"] = cat2
+    data.static = samples.StaticSamples.from_dataframe(static_df)
+
+    # Add time series categorical features.
+    # TODO:
+
+    return data
+
+
+@pytest.fixture(scope="function")
+def dummy_data_with_categorical_features_full(
+    _dummy_data_with_categorical_features_full: dataset.OneOffPredictionDataset,
+) -> dataset.OneOffPredictionDataset:
+    # Give each test a copy, just in case.
+    return copy.deepcopy(_dummy_data_with_categorical_features_full)
+
+
+# Dummy data: small, with categoricals.
+@pytest.fixture(scope="session")
+def _dummy_data_with_categorical_features_small(
+    _dummy_data_with_categorical_features_full: dataset.OneOffPredictionDataset,
+) -> dataset.OneOffPredictionDataset:
+    data = _dummy_data_with_categorical_features_full[:5]
+    return data
+
+
+@pytest.fixture(scope="function")
+def dummy_data_with_categorical_features_small(
+    _dummy_data_with_categorical_features_small: dataset.OneOffPredictionDataset,
+) -> dataset.OneOffPredictionDataset:
+    # Give each test a copy, just in case.
+    return copy.deepcopy(_dummy_data_with_categorical_features_small)

--- a/tests/plugins/preprocessing/encoding/conftest.py
+++ b/tests/plugins/preprocessing/encoding/conftest.py
@@ -29,7 +29,13 @@ def _dummy_data_with_categorical_features_full() -> dataset.OneOffPredictionData
     data.static = samples.StaticSamples.from_dataframe(static_df)
 
     # Add time series categorical features.
-    # TODO:
+    ts_df = data.time_series.dataframe()
+    np.random.seed(111)
+    cat1 = pd.Categorical(np.random.choice(["p", "q", "r"], size=(len(ts_df),)))
+    cat2 = pd.Categorical(np.random.choice(["S", "T"], size=(len(ts_df),)))
+    ts_df.insert(1, "categorical_feat_1", cat1)
+    ts_df["categorical_feat_2"] = cat2
+    data.time_series = samples.TimeSeriesSamples.from_dataframe(ts_df)
 
     return data
 

--- a/tests/plugins/preprocessing/encoding/static/test_static_onehot_encoder.py
+++ b/tests/plugins/preprocessing/encoding/static/test_static_onehot_encoder.py
@@ -1,0 +1,99 @@
+# pylint: disable=redefined-outer-name
+
+from typing import Callable, Dict
+
+import pytest
+
+from tempor.plugins.preprocessing.encoding import BaseEncoder
+from tempor.plugins.preprocessing.encoding.static.plugin_static_onehot_encoder import StaticOneHotEncoder
+from tempor.utils.serialization import load, save
+
+INIT_KWARGS = {"features": ["categorical_feat_1", "categorical_feat_2"]}
+PLUGIN_FROM_OPTIONS = ["from_api", pytest.param("from_module", marks=pytest.mark.extra)]
+TEST_ON_DATASETS = [
+    "dummy_data_with_categorical_features_small",
+    pytest.param("dummy_data_with_categorical_features_full", marks=pytest.mark.extra),
+]
+
+
+@pytest.fixture
+def get_test_plugin(get_plugin: Callable):
+    def func(plugin_from: str, base_kwargs: Dict):
+        return get_plugin(
+            plugin_from,
+            fqn="preprocessing.encoding.static.static_onehot_encoder",
+            cls=StaticOneHotEncoder,
+            kwargs=base_kwargs,
+        )
+
+    return func
+
+
+@pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
+def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
+    test_plugin = get_test_plugin(plugin_from, INIT_KWARGS)
+    assert test_plugin is not None
+    assert test_plugin.name == "static_onehot_encoder"
+    assert len(test_plugin.hyperparameter_space()) == 3
+
+
+@pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
+@pytest.mark.parametrize("data", TEST_ON_DATASETS)
+def test_fit(plugin_from: str, data: str, get_test_plugin: Callable, get_dataset: Callable) -> None:
+    test_plugin: BaseEncoder = get_test_plugin(plugin_from, INIT_KWARGS)
+    dataset = get_dataset(data)
+    test_plugin.fit(dataset)
+
+
+# @pytest.mark.filterwarnings("ignore:RNN.*contiguous.*:UserWarning")  # Expected: problem with current serialization.
+@pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
+@pytest.mark.parametrize("data", TEST_ON_DATASETS)
+@pytest.mark.parametrize(
+    "covariates_dataset",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.extra),
+    ],
+)
+def test_transform(
+    plugin_from: str,
+    data: str,
+    covariates_dataset: bool,
+    get_test_plugin: Callable,
+    get_dataset: Callable,
+    as_covariates_dataset: Callable,
+) -> None:
+    test_plugin: BaseEncoder = get_test_plugin(plugin_from, INIT_KWARGS)
+    dataset = get_dataset(data)
+
+    if covariates_dataset:
+        dataset = as_covariates_dataset(dataset)
+
+    assert dataset.static is not None  # nosec B101
+
+    dump = save(test_plugin)
+    reloaded = load(dump)
+
+    reloaded.fit(dataset)
+
+    dump = save(reloaded)
+    reloaded = load(dump)
+
+    output = reloaded.transform(dataset)
+
+    assert "categorical_feat_1" not in output.static.dataframe().columns.tolist()
+    assert "categorical_feat_2" not in output.static.dataframe().columns.tolist()
+
+    new_cols = [
+        "categorical_feat_1_a",
+        "categorical_feat_1_b",
+        "categorical_feat_1_c",
+        "categorical_feat_2_D",
+        "categorical_feat_2_E",
+    ]
+
+    for new_col in new_cols:
+        assert new_col in output.static.dataframe().columns.tolist()
+
+    for new_col in new_cols:
+        assert sorted(output.static.dataframe()[new_col].unique().tolist()) == [0.0, 1.0]

--- a/tests/plugins/preprocessing/encoding/temporal/test_ts_onehot_encoder.py
+++ b/tests/plugins/preprocessing/encoding/temporal/test_ts_onehot_encoder.py
@@ -1,0 +1,130 @@
+# pylint: disable=redefined-outer-name
+
+from typing import Callable, Dict
+
+import pytest
+
+from tempor.plugins.preprocessing.encoding import BaseEncoder
+from tempor.plugins.preprocessing.encoding.temporal.plugin_ts_onehot_encoder import TimeSeriesOneHotEncoder
+from tempor.utils.serialization import load, save
+
+INIT_KWARGS = {"features": ["categorical_feat_1", "categorical_feat_2"]}
+PLUGIN_FROM_OPTIONS = ["from_api", pytest.param("from_module", marks=pytest.mark.extra)]
+TEST_ON_DATASETS = [
+    "dummy_data_with_categorical_features_small",
+    pytest.param("dummy_data_with_categorical_features_full", marks=pytest.mark.extra),
+]
+
+
+@pytest.fixture
+def get_test_plugin(get_plugin: Callable):
+    def func(plugin_from: str, base_kwargs: Dict):
+        return get_plugin(
+            plugin_from,
+            fqn="preprocessing.encoding.temporal.ts_onehot_encoder",
+            cls=TimeSeriesOneHotEncoder,
+            kwargs=base_kwargs,
+        )
+
+    return func
+
+
+@pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
+def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
+    test_plugin = get_test_plugin(plugin_from, INIT_KWARGS)
+    assert test_plugin is not None
+    assert test_plugin.name == "ts_onehot_encoder"
+    assert len(test_plugin.hyperparameter_space()) == 3
+
+
+@pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
+@pytest.mark.parametrize("data", TEST_ON_DATASETS)
+def test_fit(plugin_from: str, data: str, get_test_plugin: Callable, get_dataset: Callable) -> None:
+    test_plugin: BaseEncoder = get_test_plugin(plugin_from, INIT_KWARGS)
+    dataset = get_dataset(data)
+    test_plugin.fit(dataset)
+
+
+@pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
+@pytest.mark.parametrize("data", TEST_ON_DATASETS)
+@pytest.mark.parametrize(
+    "covariates_dataset",
+    [
+        False,
+        pytest.param(True, marks=pytest.mark.extra),
+    ],
+)
+def test_transform(
+    plugin_from: str,
+    data: str,
+    covariates_dataset: bool,
+    get_test_plugin: Callable,
+    get_dataset: Callable,
+    as_covariates_dataset: Callable,
+) -> None:
+    test_plugin: BaseEncoder = get_test_plugin(plugin_from, INIT_KWARGS)
+    dataset = get_dataset(data)
+
+    if covariates_dataset:
+        dataset = as_covariates_dataset(dataset)
+
+    dump = save(test_plugin)
+    reloaded = load(dump)
+
+    reloaded.fit(dataset)
+
+    dump = save(reloaded)
+    reloaded = load(dump)
+
+    output = reloaded.transform(dataset)
+
+    assert "categorical_feat_1" not in output.time_series.dataframe().columns.tolist()
+    assert "categorical_feat_2" not in output.time_series.dataframe().columns.tolist()
+
+    new_cols = [
+        "categorical_feat_1_p",
+        "categorical_feat_1_q",
+        "categorical_feat_1_r",
+        "categorical_feat_2_S",
+        "categorical_feat_2_T",
+    ]
+
+    for new_col in new_cols:
+        assert new_col in output.time_series.dataframe().columns.tolist()
+
+    for new_col in new_cols:
+        assert sorted(output.time_series.dataframe()[new_col].unique().tolist()) == [0.0, 1.0]
+
+
+def test_transform_all_features(get_test_plugin: Callable, get_dataset: Callable) -> None:
+    test_plugin: BaseEncoder = get_test_plugin("from_api", {"features": None})
+    dataset = get_dataset(TEST_ON_DATASETS[0])
+
+    ts_df = dataset.time_series.dataframe()
+    ts_df.drop(
+        columns=[c for c in ts_df.columns.tolist() if c not in ["categorical_feat_1", "categorical_feat_2"]],
+        inplace=True,
+    )
+    dataset.time_series = dataset.time_series.from_dataframe(ts_df)
+
+    test_plugin.fit(dataset)
+    output = test_plugin.transform(dataset)
+
+    assert "categorical_feat_1" not in output.time_series.dataframe().columns.tolist()
+    assert "categorical_feat_2" not in output.time_series.dataframe().columns.tolist()
+
+    assert len(output.time_series.dataframe().columns) == 5
+
+    new_cols = [
+        "categorical_feat_1_p",
+        "categorical_feat_1_q",
+        "categorical_feat_1_r",
+        "categorical_feat_2_S",
+        "categorical_feat_2_T",
+    ]
+
+    for new_col in new_cols:
+        assert new_col in output.time_series.dataframe().columns.tolist()
+
+    for new_col in new_cols:
+        assert sorted(output.time_series.dataframe()[new_col].unique().tolist()) == [0.0, 1.0]

--- a/tests/plugins/test_plugin_loader.py
+++ b/tests/plugins/test_plugin_loader.py
@@ -14,6 +14,7 @@ def test_tempor_plugin_loader_contents():
     assert "treatments" in all_plugins
 
     # Check subcategories:
+    assert "encoding" in all_plugins["preprocessing"]
     assert "imputation" in all_plugins["preprocessing"]
     assert "scaling" in all_plugins["preprocessing"]
     assert "nop" in all_plugins["preprocessing"]
@@ -27,6 +28,8 @@ def test_tempor_plugin_loader_contents():
     assert "regression" in all_plugins["prediction"]["one_off"]
     assert "classification" in all_plugins["prediction"]["temporal"]
     assert "regression" in all_plugins["prediction"]["temporal"]
+    assert "static" in all_plugins["preprocessing"]["encoding"]
+    # assert "temporal" in all_plugins["preprocessing"]["encoding"]
     assert "static" in all_plugins["preprocessing"]["imputation"]
     assert "temporal" in all_plugins["preprocessing"]["imputation"]
     assert "static" in all_plugins["preprocessing"]["scaling"]
@@ -52,6 +55,9 @@ def test_tempor_plugin_loader_contents():
     assert "seq2seq_regressor" in all_plugins["prediction"]["temporal"]["regression"]
     # ---
     assert "nop_transformer" in all_plugins["preprocessing"]["nop"]
+    # ---
+    assert "static_onehot_encoder" in all_plugins["preprocessing"]["encoding"]["static"]
+    # assert "ts_onehot_encoder" in all_plugins["preprocessing"]["encoding"]["temporal"]
     # ---
     assert "static_tabular_imputer" in all_plugins["preprocessing"]["imputation"]["static"]
     assert "ts_tabular_imputer" in all_plugins["preprocessing"]["imputation"]["temporal"]

--- a/tests/plugins/test_plugin_loader.py
+++ b/tests/plugins/test_plugin_loader.py
@@ -29,7 +29,7 @@ def test_tempor_plugin_loader_contents():
     assert "classification" in all_plugins["prediction"]["temporal"]
     assert "regression" in all_plugins["prediction"]["temporal"]
     assert "static" in all_plugins["preprocessing"]["encoding"]
-    # assert "temporal" in all_plugins["preprocessing"]["encoding"]
+    assert "temporal" in all_plugins["preprocessing"]["encoding"]
     assert "static" in all_plugins["preprocessing"]["imputation"]
     assert "temporal" in all_plugins["preprocessing"]["imputation"]
     assert "static" in all_plugins["preprocessing"]["scaling"]
@@ -57,7 +57,7 @@ def test_tempor_plugin_loader_contents():
     assert "nop_transformer" in all_plugins["preprocessing"]["nop"]
     # ---
     assert "static_onehot_encoder" in all_plugins["preprocessing"]["encoding"]["static"]
-    # assert "ts_onehot_encoder" in all_plugins["preprocessing"]["encoding"]["temporal"]
+    assert "ts_onehot_encoder" in all_plugins["preprocessing"]["encoding"]["temporal"]
     # ---
     assert "static_tabular_imputer" in all_plugins["preprocessing"]["imputation"]["static"]
     assert "ts_tabular_imputer" in all_plugins["preprocessing"]["imputation"]["temporal"]


### PR DESCRIPTION
## Description
Introduces `StaticOneHotEncoder` and `TimeSeriesOneHotEncoder` based on `sklearn`'s `OneHotEncoder`.

## Affected Dependencies
None.

## How has this been tested?
Tests for the new plugins written in:
* `tests/plugins/preprocessing/encoding/static/test_static_onehot_encoder.py`
* `tests/plugins/preprocessing/encoding/temporal/test_ts_onehot_encoder.py`
Additional test datasets added in:
* `tests/plugins/preprocessing/encoding/conftest.py`
Plugin loader tests updated in:
* `tests/plugins/test_plugin_loader.py`

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
