### PR TITLE
Improve DDH model early stopping handling

### DIFF
--- a/src/tempor/models/ddh.py
+++ b/src/tempor/models/ddh.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import deepcopy
 from typing import Any, List, Optional, Tuple, Union
 
@@ -248,6 +249,18 @@ class DynamicDeepHitModel:
         e_train = torch.from_numpy(e_train_np.astype(int)).float().to(self.device)
 
         val_size = int(self.val_size * x_train.shape[0])
+        if val_size == 0:
+            raise RuntimeError(
+                f"Not enough samples to create a validation set, please increase `val_size` or use a larger dataset. "
+                f"`val_size` was {val_size} and total number of samples in dataset was {x_train.shape[0]}."
+            )
+        if val_size < 10:
+            # Raise a UserWarning if the validation set is very small.
+            warnings.warn(
+                f"Validation set is very small ({val_size} samples). "
+                "Consider increasing `val_size` or using a larger dataset.",
+                UserWarning,
+            )
 
         x_val, t_val, e_val = x_train[-val_size:], t_train[-val_size:], e_train[-val_size:]
 

--- a/src/tempor/plugins/time_to_event/plugin_ddh.py
+++ b/src/tempor/plugins/time_to_event/plugin_ddh.py
@@ -36,8 +36,10 @@ class DynamicDeepHitTimeToEventAnalysisParams:
     """Network dropout value."""
     device: str = "cpu"
     """PyTorch Device."""
+    val_size: float = 0.1
+    """Early stopping: size of validation set."""
     patience: int = 20
-    """Training patience without any improvement."""
+    """Early stopping: training patience without any improvement."""
     output_mode: OutputMode = "MLP"
     """Output network, on of `OutputMode`."""
     random_state: int = 0
@@ -76,6 +78,7 @@ class DynamicDeepHitTimeToEventAnalysis(BaseTimeToEventAnalysis, DDHEmbedding):
             beta=self.params.beta,
             sigma=self.params.sigma,
             dropout=self.params.dropout,
+            val_size=self.params.val_size,
             patience=self.params.patience,
             lr=self.params.lr,
             batch_size=self.params.batch_size,

--- a/src/tempor/plugins/time_to_event/plugin_ts_coxph.py
+++ b/src/tempor/plugins/time_to_event/plugin_ts_coxph.py
@@ -84,8 +84,10 @@ class CoxPHTimeToEventAnalysisParams:
     """Network dropout value."""
     device: str = "cpu"
     """PyTorch Device."""
+    val_size: float = 0.1
+    """Early stopping (embeddings training): size of validation set."""
     patience: int = 20
-    """Training patience without any improvement."""
+    """Early stopping (embeddings training): training patience without any improvement."""
     output_mode: OutputMode = "MLP"
     """Output network, on of `OutputMode`."""
     random_state: int = 0
@@ -193,6 +195,7 @@ class CoxPHTimeToEventAnalysis(BaseTimeToEventAnalysis):
                 beta=self.params.beta,
                 sigma=self.params.sigma,
                 dropout=self.params.dropout,
+                val_size=self.params.val_size,
                 patience=self.params.patience,
                 lr=self.params.lr,
                 batch_size=self.params.batch_size,

--- a/src/tempor/plugins/time_to_event/plugin_ts_xgb.py
+++ b/src/tempor/plugins/time_to_event/plugin_ts_xgb.py
@@ -83,8 +83,10 @@ class XGBTimeToEventAnalysisParams:
     """Network dropout value."""
     device: str = "cpu"
     """PyTorch Device."""
+    val_size: float = 0.1
+    """Early stopping (embeddings training): size of validation set."""
     patience: int = 20
-    """Training patience without any improvement."""
+    """Early stopping (embeddings training): training patience without any improvement."""
     output_mode: OutputMode = "MLP"
     """Output network, on of `OutputMode`."""
     random_state: int = 0
@@ -251,6 +253,7 @@ class XGBTimeToEventAnalysis(BaseTimeToEventAnalysis):
                 beta=self.params.beta,
                 sigma=self.params.sigma,
                 dropout=self.params.dropout,
+                val_size=self.params.val_size,
                 patience=self.params.patience,
                 lr=self.params.lr,
                 batch_size=self.params.batch_size,

--- a/tests/benchmarks/test_evaluation.py
+++ b/tests/benchmarks/test_evaluation.py
@@ -209,6 +209,7 @@ def test_evaluate_prediction_oneoff_regressor_error(
         assert (scores["errors"] > 0).all()
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Expected for small test datasets with DDH.
 @pytest.mark.parametrize("data", TEST_ON_DATASETS_TIME_TO_EVENT)
 @pytest.mark.parametrize(
     "model_template",

--- a/tests/models/test_ddh.py
+++ b/tests/models/test_ddh.py
@@ -92,6 +92,20 @@ def test_ddh_predict_output_modes(
     assert output.shape == (len(x), len(horizons))
 
 
+def test_val_set_fail(get_test_data):
+    x, t, e, _ = get_test_data
+    model = DynamicDeepHitModel(n_iter=10, clipping_value=0, val_size=0.0001)
+    with pytest.raises(RuntimeError, match=".*[Vv]alidation.*"):
+        model.fit(x=x, t=t, e=e)
+
+
+def test_val_set_too_small_warning(get_test_data):
+    x, t, e, _ = get_test_data
+    model = DynamicDeepHitModel(n_iter=10, clipping_value=0, val_size=(5 / len(x)))
+    with pytest.warns(UserWarning, match=".*[Vv]alidation.*small.*"):
+        model.fit(x=x, t=t, e=e)
+
+
 def test_ddh_predict_more_cases(get_test_data):
     x, t, e, horizons = get_test_data
 

--- a/tests/plugins/pipelines/test_pipeline_end2end.py
+++ b/tests/plugins/pipelines/test_pipeline_end2end.py
@@ -339,6 +339,7 @@ def test_end2end_prediction_temporal_regression(
 # Category: time_to_event:
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Expected for small test datasets with DDH.
 @pytest.mark.parametrize(
     "plugins_str",
     [

--- a/tests/plugins/time_to_event/test_ddh_plugin.py
+++ b/tests/plugins/time_to_event/test_ddh_plugin.py
@@ -43,6 +43,7 @@ def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
     assert len(test_plugin.hyperparameter_space()) == 10
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Expected for small test datasets.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 @pytest.mark.parametrize("device", DEVICES)
@@ -52,6 +53,7 @@ def test_fit(plugin_from: str, data: str, device: str, get_test_plugin: Callable
     test_plugin.fit(dataset)
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Expected for small test datasets.
 @pytest.mark.filterwarnings("ignore:RNN.*contiguous.*:UserWarning")  # Expected: problem with current serialization.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
@@ -82,6 +84,7 @@ def test_predict(
     assert output.numpy().shape == (len(dataset.time_series), len(horizons), 1)
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Expected for small test datasets.
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 @pytest.mark.parametrize("device", DEVICES)
 def test_benchmark(

--- a/tests/plugins/time_to_event/test_ts_coxph_plugin.py
+++ b/tests/plugins/time_to_event/test_ts_coxph_plugin.py
@@ -49,6 +49,7 @@ def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
     assert len(test_plugin.hyperparameter_space()) == 12
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Exp. for small datasets with DDH embedding.
 @pytest.mark.filterwarnings("ignore::lifelines.utils.ConvergenceWarning")  # Expected.
 @pytest.mark.filterwarnings("ignore:.*Index constructor.*:FutureWarning")
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
@@ -60,6 +61,7 @@ def test_fit(plugin_from: str, data: str, device: str, get_test_plugin: Callable
     test_plugin.fit(dataset)
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Exp. for small datasets with DDH embedding.
 @pytest.mark.filterwarnings("ignore:RNN.*contiguous.*:UserWarning")  # Expected: problem with current serialization.
 @pytest.mark.filterwarnings("ignore::lifelines.utils.ConvergenceWarning")  # Expected.
 @pytest.mark.filterwarnings("ignore:.*Index constructor.*:FutureWarning")
@@ -92,6 +94,7 @@ def test_predict(
     assert output.numpy().shape == (len(dataset.time_series), len(horizons), 1)
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Exp. for small datasets with DDH embedding.
 @pytest.mark.filterwarnings("ignore::lifelines.utils.ConvergenceWarning")  # Expected.
 @pytest.mark.filterwarnings("ignore:.*Index constructor.*:FutureWarning")
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)

--- a/tests/plugins/time_to_event/test_ts_xgb_plugin.py
+++ b/tests/plugins/time_to_event/test_ts_xgb_plugin.py
@@ -44,6 +44,7 @@ def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
     assert len(test_plugin.hyperparameter_space()) == 23
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Exp. for small datasets with DDH embedding.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 @pytest.mark.parametrize("device", DEVICES)
@@ -53,6 +54,7 @@ def test_fit(plugin_from: str, data: str, device: str, get_test_plugin: Callable
     test_plugin.fit(dataset)
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Exp. for small datasets with DDH embedding.
 @pytest.mark.filterwarnings("ignore:RNN.*contiguous.*:UserWarning")  # Expected: problem with current serialization.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
@@ -83,6 +85,7 @@ def test_predict(
     assert output.numpy().shape == (len(dataset.time_series), len(horizons), 1)
 
 
+@pytest.mark.filterwarnings("ignore:.*Validation.*small.*:UserWarning")  # Exp. for small datasets with DDH embedding.
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 @pytest.mark.parametrize("device", DEVICES)
 def test_benchmark(


### PR DESCRIPTION
## Description
* Pass early stopping `val_size` to DDH model and DDH embedding model (from relevant plugins).
* Raise error or warning for when this validation set ends up with 0 samples, or too few samples (<10), respectively.

## Affected Dependencies
None.

## How has this been tested?
- New tests added in `tests/models/test_ddh.py`

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
