### PR TITLE
Fix DDH prediction batch size

### DIFF
--- a/src/tempor/models/ddh.py
+++ b/src/tempor/models/ddh.py
@@ -289,7 +289,7 @@ class DynamicDeepHitModel:
         t: List,
         risk: int = 1,
         all_step: bool = False,
-        bs: int = 100,
+        batch_size: int = 100,
     ) -> np.ndarray:
         if self.model is None:
             raise RuntimeError(
@@ -310,10 +310,10 @@ class DynamicDeepHitModel:
         t = self.discretize([t], self.split, self.split_time)[0][0]  # type: ignore
 
         x_in_tensor: torch.Tensor = self._preprocess_test_data(x_in)
-        batches = int(len(x) / bs) + 1
+        batches = int(len(x) / batch_size) + 1
         scores: dict = {t_: [] for t_ in t}
         for j in range(batches):
-            xb = x_in_tensor[j * self.batch_size : (j + 1) * self.batch_size]
+            xb = x_in_tensor[j * batch_size : (j + 1) * batch_size]
             _, f = self.model(xb)  # pylint: disable=not-callable
             for t_ in t:
                 pred = torch.cumsum(f[int(risk) - 1], dim=1)[:, t_].squeeze().detach().cpu().numpy().tolist()

--- a/src/tempor/plugins/time_to_event/helper_embedding.py
+++ b/src/tempor/plugins/time_to_event/helper_embedding.py
@@ -172,7 +172,7 @@ class DDHEmbeddingTimeToEventAnalysis(DDHEmbedding):
         **kwargs,
     ) -> samples.TimeSeriesSamples:
         # NOTE: kwargs will be passed to DynamicDeepHitModel.predict_emb().
-        # E.g. `bs` batch size parameter can be provided this way.
+        # E.g. `batch_size` batch size parameter can be provided this way.
         processed_data = self.prepare_predict(data, horizons, *args, **kwargs)
 
         embeddings = self.emb_model.predict_emb(processed_data)

--- a/src/tempor/plugins/time_to_event/plugin_ddh.py
+++ b/src/tempor/plugins/time_to_event/plugin_ddh.py
@@ -106,7 +106,7 @@ class DynamicDeepHitTimeToEventAnalysis(BaseTimeToEventAnalysis, DDHEmbedding):
         **kwargs,
     ) -> samples.TimeSeriesSamples:
         # NOTE: kwargs will be passed to DynamicDeepHitModel.predict_risk().
-        # E.g. `bs` batch size parameter can be provided this way.
+        # E.g. `batch_size` batch size parameter can be provided this way.
         processed_data = self.prepare_predict(data, horizons, *args, **kwargs)
         risk = self.model.predict_risk(processed_data, horizons, **kwargs)
         return samples.TimeSeriesSamples(


### PR DESCRIPTION
## Description
There was a bug in `src/tempor/models/ddh.py` `DynamicDeepHitModel::predict_survival` where locally passed `bs` and `self.batch_size` were (incorrectly) both used in the loop. Fixed by using only `bs` (also renamed to `batch_size` for clarity).

## Affected Dependencies
None.

## How has this been tested?
- New test added `tests/plugins/time_to_event/test_ddh_plugin.py::test_predict_custom_bs`

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
