### PR TITLE
Make changes for pydantic 2, require pydantic >= 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     -   id: mypy
         files: "^src/"
         args: [--config-file=mypy.ini]
-        additional_dependencies: [pydantic<2]
+        additional_dependencies: [pydantic>=2]
 
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,9 +72,9 @@ install_requires =
     numpy >=1
     optuna >= 2.8.0
     packaging
-    pandas >=1
-    pandera >=0.13
-    pydantic >=1, <2
+    pandas >= 1
+    pandera >= 0.17.0
+    pydantic >= 2
     rich
     scikit-learn >= 1.0
     scipy

--- a/src/tempor/__init__.py
+++ b/src/tempor/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 if sys.version_info[:2] >= (3, 8):  # pragma: no cover
     from importlib.metadata import PackageNotFoundError, version
@@ -17,6 +18,17 @@ finally:
 
 # Import the config type and the configure function:
 from .config import TemporConfig, configure, get_config
+
+# Import the config type and the configure function:
+# Global warnings suppression:
+warnings.filterwarnings("ignore", message=".*validate_arguments.*", category=DeprecationWarning)
+
+# NOTE:
+# Currently, migrating to Pydantic 2.0's validate_call decorator is not possible due to several incompatibilities, e.g.:
+# - cloudpickle fails to pickle objects: TypeError: cannot pickle 'EncodedFile' object.
+# - PipelineMeta setup is incompatible, triggers: TypeError: can't apply this __setattr__ to ABCMeta object.
+# For the time being, reasonable to stick to validate_arguments and silence Pydantic 2.0's deprecation warning.
+
 
 __all__ = [
     "get_config",

--- a/src/tempor/automl/seeker.py
+++ b/src/tempor/automl/seeker.py
@@ -187,7 +187,7 @@ def evaluation_callback_dispatch(
 
 
 class BaseSeeker(abc.ABC):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         study_name: str,
@@ -480,7 +480,7 @@ class BaseSeeker(abc.ABC):
 
 
 class MethodSeeker(BaseSeeker):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         study_name: str,
@@ -589,7 +589,7 @@ class MethodSeeker(BaseSeeker):
 
 
 class PipelineSeeker(BaseSeeker):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         study_name: str,

--- a/src/tempor/automl/tuner.py
+++ b/src/tempor/automl/tuner.py
@@ -5,7 +5,7 @@ import copy
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import optuna
-from pydantic import validate_arguments
+import pydantic
 from typing_extensions import Protocol, runtime_checkable
 
 from tempor.data.dataset import PredictiveDataset
@@ -40,7 +40,7 @@ class EvaluationCallback(Protocol):
 
 
 class BaseTuner(abc.ABC):
-    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         study_name: str,
@@ -95,7 +95,7 @@ class BaseTuner(abc.ABC):
 
 
 class OptunaTuner(BaseTuner):
-    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         study_name: str,

--- a/src/tempor/benchmarks/benchmark.py
+++ b/src/tempor/benchmarks/benchmark.py
@@ -23,7 +23,7 @@ def print_score(mean: pd.Series, std: pd.Series) -> pd.Series:
     return mean + " +/- " + std
 
 
-@pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def benchmark_models(
     task_type: PredictiveTaskType,
     tests: List[Tuple[str, Any]],  # [ ( Test name, Model to evaluate (unfitted) ), ... ]
@@ -130,7 +130,7 @@ def benchmark_models(
     return aggr, results
 
 
-@pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def visualize_benchmark(results: Dict[str, pd.DataFrame], palette: str = "viridis") -> Any:
     # Pre-format DF for plotting.
     for k, v in results.items():

--- a/src/tempor/benchmarks/evaluation.py
+++ b/src/tempor/benchmarks/evaluation.py
@@ -171,12 +171,10 @@ class _InternalScores(pydantic.BaseModel):
     metrics: Dict[str, np.ndarray] = {}  # np.ndarray expected to be 1D, contain floats.
     errors: List[int] = []
     durations: List[float] = []
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
 
-@pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def _postprocess_results(results: _InternalScores) -> pd.DataFrame:
     output = pd.DataFrame([], columns=output_metrics)
 
@@ -220,7 +218,7 @@ def _postprocess_results(results: _InternalScores) -> pd.DataFrame:
 
 
 class ClassifierMetrics:
-    @pydantic.validate_arguments
+    @pydantic.validate_arguments  # type: ignore [operator]
     def __init__(
         self,
         metric: Union[ClassifierSupportedMetric, Sequence[ClassifierSupportedMetric]] = classifier_supported_metrics,
@@ -335,7 +333,7 @@ class ClassifierMetrics:
         return utils.evaluate_auc_multiclass(y_test, y_pred_proba)[1]
 
 
-@pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def evaluate_prediction_oneoff_classifier(  # pylint: disable=unused-argument
     estimator: Any,
     data: dataset.PredictiveDataset,
@@ -424,7 +422,7 @@ def evaluate_prediction_oneoff_classifier(  # pylint: disable=unused-argument
     return _postprocess_results(results)
 
 
-@pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def evaluate_prediction_oneoff_regressor(  # pylint: disable=unused-argument
     estimator: Any,
     data: dataset.PredictiveDataset,
@@ -585,7 +583,7 @@ def _compute_time_to_event_metric(
     return avg_metric
 
 
-@pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def evaluate_time_to_event(  # pylint: disable=unused-argument
     estimator: Any,
     data: dataset.TimeToEventAnalysisDataset,

--- a/src/tempor/core/pydantic_utils.py
+++ b/src/tempor/core/pydantic_utils.py
@@ -1,6 +1,7 @@
 from typing import Any, Type
 
 import pydantic
+from packaging.version import Version
 
 # Currently unused.
 # def exclusive_args(
@@ -19,7 +20,10 @@ import pydantic
 
 
 def is_pydantic_dataclass(cls: Type) -> bool:
-    return hasattr(cls, "__dataclass__")
+    if Version(pydantic.__version__) < Version("2.0.0"):  # pragma: no cover
+        return hasattr(cls, "__dataclass__")
+    else:
+        return any([x for x in dir(cls) if "pydantic" in x])
 
 
 PYDANTIC_DATACLASS_WORKAROUND_DICT = dict()

--- a/src/tempor/data/samples.py
+++ b/src/tempor/data/samples.py
@@ -161,7 +161,7 @@ class StaticSamples(DataSamples):
     _data: pd.DataFrame
     _schema: pa.DataFrameSchema
 
-    @pydantic.validate_arguments(config={"arbitrary_types_allowed": True, "smart_union": True})
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         data: data_typing.DataContainer,
@@ -333,7 +333,7 @@ class TimeSeriesSamples(DataSamples):
     def modality(self) -> data_typing.DataModality:
         return data_typing.DataModality.TIME_SERIES
 
-    @pydantic.validate_arguments(config={"arbitrary_types_allowed": True, "smart_union": True})
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         data: data_typing.DataContainer,
@@ -604,7 +604,7 @@ class EventSamples(DataSamples):
     def modality(self) -> data_typing.DataModality:
         return data_typing.DataModality.EVENT
 
-    @pydantic.validate_arguments(config={"arbitrary_types_allowed": True, "smart_union": True})
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         data: data_typing.DataContainer,
@@ -743,7 +743,7 @@ class EventSamples(DataSamples):
     def num_features(self) -> int:
         return self._data.shape[1]
 
-    @pydantic.validate_arguments(config={"arbitrary_types_allowed": True})
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def split(self, time_feature_suffix: str = _DEFAULT_EVENTS_TIME_FEATURE_SUFFIX) -> pd.DataFrame:
         """Return a `pandas.DataFrame` where the time component of each event feature has been split off to its own
         column. The new columns that contain the times will be named ``"<original column name><time_feature_suffix>"``

--- a/src/tempor/data/utils.py
+++ b/src/tempor/data/utils.py
@@ -45,7 +45,7 @@ def get_df_index_level0_unique(df: pd.DataFrame) -> pd.Index:
 # --- Multiindex timeseries dataframe --> 3D numpy array. ---
 
 
-@pydantic.validate_arguments(config={"arbitrary_types_allowed": True, "smart_union": True})
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def multiindex_timeseries_dataframe_to_array3d(
     df: pd.DataFrame, *, padding_indicator: Any, max_timesteps: Optional[int] = None
 ) -> np.ndarray:
@@ -271,7 +271,7 @@ def make_sample_time_index_tuples(
     return pairs  # type: ignore
 
 
-@pydantic.validate_arguments(config={"arbitrary_types_allowed": True, "smart_union": True})
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def array3d_to_multiindex_timeseries_dataframe(
     array: np.ndarray,
     *,
@@ -319,7 +319,7 @@ def array3d_to_multiindex_timeseries_dataframe(
 # --- List of dataframes --> Multiindex timeseries dataframe. ---
 
 
-@pydantic.validate_arguments(config={"arbitrary_types_allowed": True, "smart_union": True})
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def list_of_dataframes_to_multiindex_timeseries_dataframe(
     list_of_dataframes: List[pd.DataFrame],
     *,
@@ -380,7 +380,7 @@ def multiindex_timeseries_dataframe_to_list_of_dataframes(df: pd.DataFrame) -> L
 # --- [(event_times, event_values), ...] --> DataFrame compatible with EventSamples. ---
 
 
-@pydantic.validate_arguments(config={"arbitrary_types_allowed": False, "smart_union": True})
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def event_time_value_pairs_to_event_dataframe(
     event_time_value_pairs: Sequence[Tuple[data_typing.TimeIndex, List[bool]]],
     sample_index: data_typing.SampleIndex,
@@ -426,7 +426,7 @@ def event_time_value_pairs_to_event_dataframe(
 # --- Date-time time index -related ---
 
 
-@pydantic.validate_arguments(config={"arbitrary_types_allowed": True, "smart_union": True})
+@pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
 def datetime_time_index_to_float(time_index: Union[data_typing.TimeIndex, pd.Index, pd.Series]) -> np.ndarray:
     """Convert a date-time ``time_index`` to floats. The conversion is done by calling
     ``<time_index as a numpy array>.astype(float)``.

--- a/src/tempor/models/mlp.py
+++ b/src/tempor/models/mlp.py
@@ -14,7 +14,7 @@ from .utils import GumbelSoftmax, get_nonlin
 
 
 class LinearLayer(nn.Module):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         n_units_in: int,
@@ -41,13 +41,13 @@ class LinearLayer(nn.Module):
 
         self.model = nn.Sequential(*layers).to(self.device)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def forward(self, X: torch.Tensor) -> torch.Tensor:
         return self.model(X.float()).to(self.device)  # pylint: disable=not-callable
 
 
 class ResidualLayer(LinearLayer):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         n_units_in: int,
@@ -68,7 +68,7 @@ class ResidualLayer(LinearLayer):
         self.device = device
         self.n_units_out = n_units_out
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def forward(self, X: torch.Tensor) -> torch.Tensor:
         if X.shape[-1] == 0:
             return torch.zeros((*X.shape[:-1], self.n_units_out)).to(self.device)
@@ -94,7 +94,7 @@ class MultiActivationHead(nn.Module):
             self.activations.append(activation)
             self.activation_lengths.append(length)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def forward(self, X: torch.Tensor) -> torch.Tensor:
         if X.shape[-1] != np.sum(self.activation_lengths):
             raise RuntimeError(
@@ -113,7 +113,7 @@ class MultiActivationHead(nn.Module):
 
 
 class MLP(nn.Module):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         task_type: constants.ModelTaskType,
@@ -300,7 +300,7 @@ class MLP(nn.Module):
 
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
         if self.task_type != "classification":
             raise ValueError(f"Invalid task type for predict_proba {self.task_type}")
@@ -312,7 +312,7 @@ class MLP(nn.Module):
 
             return yt.cpu().numpy().squeeze()
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(self, X: np.ndarray) -> np.ndarray:
         with torch.no_grad():
             Xt = self._check_tensor(X)
@@ -331,7 +331,7 @@ class MLP(nn.Module):
         else:
             return np.mean(np.inner(y - y_pred, y - y_pred) / 2.0)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def forward(self, X: torch.Tensor) -> torch.Tensor:
         return self.model(X.float())  # pylint: disable=not-callable
 

--- a/src/tempor/models/samplers.py
+++ b/src/tempor/models/samplers.py
@@ -2,9 +2,9 @@ from typing import Any, Generator, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+import pydantic
 import torch
 import torch.utils.data.sampler
-from pydantic import validate_arguments
 from sklearn.model_selection import train_test_split
 
 
@@ -14,13 +14,13 @@ class BaseSampler(torch.utils.data.sampler.Sampler):
     def get_dataset_conditionals(self) -> Optional[np.ndarray]:  # pragma: no cover
         return None
 
-    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def sample_conditional(
         self, batch: int, **kwargs: Any  # pylint: disable=unused-argument
     ) -> Optional[Tuple]:  # pragma: no cover
         return None
 
-    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def sample_conditional_for_class(
         self, batch: int, c: int  # pylint: disable=unused-argument
     ) -> Optional[np.ndarray]:  # pragma: no cover
@@ -41,7 +41,7 @@ class BaseSampler(torch.utils.data.sampler.Sampler):
 class ImbalancedDatasetSampler(BaseSampler):
     """Samples elements randomly from a given list of indices for imbalanced dataset."""
 
-    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(self, labels: List, train_size: float = 0.8) -> None:
         super().__init__(None)
 

--- a/src/tempor/models/ts_model.py
+++ b/src/tempor/models/ts_model.py
@@ -41,7 +41,7 @@ TSModelMode = Literal[
 
 
 class TimeSeriesModel(nn.Module):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         task_type: ModelTaskType,
@@ -219,7 +219,7 @@ class TimeSeriesModel(nn.Module):
             weight_decay=weight_decay,
         )  # optimize all rnn parameters
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def forward(
         self,
         static_data: torch.Tensor,
@@ -254,7 +254,7 @@ class TimeSeriesModel(nn.Module):
 
         return pred
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(
         self,
         static_data: Union[List, np.ndarray],
@@ -286,7 +286,7 @@ class TimeSeriesModel(nn.Module):
             else:
                 return yt.cpu().numpy()
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict_proba(
         self,
         static_data: Union[List, np.ndarray],
@@ -330,7 +330,7 @@ class TimeSeriesModel(nn.Module):
         else:
             return np.mean(np.inner(outcome - y_pred, outcome - y_pred) / 2.0)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def fit(
         self,
         static_data: Union[List, np.ndarray],
@@ -348,7 +348,7 @@ class TimeSeriesModel(nn.Module):
 
         return self._train(static_data_t, temporal_data_t, observation_times_t, outcome_t)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def _train(
         self,
         static_data: List[torch.Tensor],
@@ -691,7 +691,7 @@ class TimeSeriesLayer(nn.Module):
 
 
 class WindowLinearLayer(nn.Module):
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def __init__(
         self,
         n_static_units_in: int,
@@ -720,7 +720,7 @@ class WindowLinearLayer(nn.Module):
             device=device,
         )
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def forward(self, static_data: torch.Tensor, temporal_data: torch.Tensor) -> torch.Tensor:
         if self.n_static_units_in > 0 and len(static_data) != len(temporal_data):
             raise ValueError("Length mismatch between static and temporal data")

--- a/src/tempor/models/ts_ode.py
+++ b/src/tempor/models/ts_ode.py
@@ -481,7 +481,7 @@ class NeuralODE(torch.nn.Module):
         out = self.output(z_T)
         return out.reshape(-1, *self.output_shape)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(
         self,
         static_data: Union[List, np.ndarray, torch.Tensor],
@@ -513,7 +513,7 @@ class NeuralODE(torch.nn.Module):
             else:
                 return yt.cpu().numpy()
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict_proba(
         self,
         static_data: Union[List, np.ndarray, torch.Tensor],
@@ -558,7 +558,7 @@ class NeuralODE(torch.nn.Module):
         else:
             return np.mean(np.inner(outcome - y_pred, outcome - y_pred) / 2.0)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def fit(
         self,
         static_data: Union[List, np.ndarray, torch.Tensor],
@@ -576,7 +576,7 @@ class NeuralODE(torch.nn.Module):
 
         return self._train(static_data_t, temporal_data_t, observation_times_t, outcome_t)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def _train(
         self,
         static_data: List[torch.Tensor],

--- a/src/tempor/plugins/core/_base_estimator.py
+++ b/src/tempor/plugins/core/_base_estimator.py
@@ -26,13 +26,13 @@ class BaseEstimator(Plugin, abc.ABC):
     _fitted: bool
 
     class _InitArgsValidator(pydantic.BaseModel):
-        params: Optional[Dict[str, Any]]
+        params: Optional[Dict[str, Any]] = None
         ParamsDefinitionClass: Type
 
         # Output:
         params_processed: Optional[omegaconf.DictConfig] = None
 
-        @pydantic.root_validator
+        @pydantic.model_validator(mode="before")
         def root_checks(cls, values: Dict):  # pylint: disable=no-self-argument
             params = values.get("params", dict())
             ParamsDefinitionClass = values.get("ParamsDefinitionClass")
@@ -54,8 +54,7 @@ class BaseEstimator(Plugin, abc.ABC):
             values["params_processed"] = defined_params
             return values
 
-        class Config:
-            arbitrary_types_allowed = True
+        model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **params) -> None:
         Plugin.__init__(self)
@@ -79,7 +78,7 @@ class BaseEstimator(Plugin, abc.ABC):
     def __repr__(self) -> str:
         return rich.pretty.pretty_repr(self)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def fit(
         self,
         data: dataset.BaseDataset,

--- a/src/tempor/plugins/core/_base_predictor.py
+++ b/src/tempor/plugins/core/_base_predictor.py
@@ -68,7 +68,7 @@ class BasePredictor(estimator.BaseEstimator):
         return prediction
 
     # TODO: Add similar methods for predict_{proba,counterfactuals}.
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def fit_predict(
         self,
         data: dataset.PredictiveDataset,

--- a/src/tempor/plugins/core/_base_transformer.py
+++ b/src/tempor/plugins/core/_base_transformer.py
@@ -24,7 +24,7 @@ class BaseTransformer(estimator.BaseEstimator):
 
         return transformed_data
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def fit_transform(
         self,
         data: dataset.BaseDataset,

--- a/src/tempor/plugins/prediction/one_off/classification/__init__.py
+++ b/src/tempor/plugins/prediction/one_off/classification/__init__.py
@@ -26,7 +26,7 @@ class BaseOneOffClassifier(plugins.BasePredictor):
         super().fit(data, *args, **kwargs)
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(
         self,
         data: dataset.PredictiveDataset,
@@ -36,7 +36,7 @@ class BaseOneOffClassifier(plugins.BasePredictor):
         check_data_class(data)
         return super().predict(data, *args, **kwargs)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict_proba(
         self,
         data: dataset.PredictiveDataset,

--- a/src/tempor/plugins/prediction/one_off/classification/plugin_nn_classifier.py
+++ b/src/tempor/plugins/prediction/one_off/classification/plugin_nn_classifier.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from typing_extensions import Self, get_args
@@ -129,6 +129,9 @@ class NeuralNetClassifier(BaseOneOffClassifier):
             patience=self.params.patience,
             train_ratio=self.params.train_ratio,
         )
+
+        if TYPE_CHECKING:  # pragma: no cover
+            assert isinstance(self.model, TimeSeriesModel)  # nosec B101
 
         self.model.fit(static, temporal, observation_times, outcome)
         return self

--- a/src/tempor/plugins/prediction/one_off/regression/__init__.py
+++ b/src/tempor/plugins/prediction/one_off/regression/__init__.py
@@ -26,7 +26,7 @@ class BaseOneOffRegressor(plugins.BasePredictor):
         super().fit(data, *args, **kwargs)
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(
         self,
         data: dataset.PredictiveDataset,

--- a/src/tempor/plugins/prediction/one_off/regression/plugin_nn_regressor.py
+++ b/src/tempor/plugins/prediction/one_off/regression/plugin_nn_regressor.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import Self, get_args
 
@@ -126,6 +126,9 @@ class NeuralNetRegressor(BaseOneOffRegressor):
             patience=self.params.patience,
             train_ratio=self.params.train_ratio,
         )
+
+        if TYPE_CHECKING:  # pragma: no cover
+            assert isinstance(self.model, TimeSeriesModel)  # nosec B101
 
         self.model.fit(static, temporal, observation_times, outcome)
         return self

--- a/src/tempor/plugins/prediction/temporal/classification/__init__.py
+++ b/src/tempor/plugins/prediction/temporal/classification/__init__.py
@@ -24,7 +24,7 @@ class BaseTemporalClassifier(plugins.BasePredictor):
         super().fit(data, *args, **kwargs)
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(  # type: ignore[override]  # pylint: disable=arguments-differ
         self,
         data: dataset.PredictiveDataset,
@@ -36,7 +36,7 @@ class BaseTemporalClassifier(plugins.BasePredictor):
         check_data_class(data)
         return super().predict(data, n_future_steps, *args, time_delta=time_delta, **kwargs)
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict_proba(  # type: ignore[override]  # pylint: disable=arguments-differ
         self,
         data: dataset.PredictiveDataset,

--- a/src/tempor/plugins/prediction/temporal/regression/__init__.py
+++ b/src/tempor/plugins/prediction/temporal/regression/__init__.py
@@ -24,7 +24,7 @@ class BaseTemporalRegressor(plugins.BasePredictor):
         super().fit(data, *args, **kwargs)
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(  # type: ignore[override]  # pylint: disable=arguments-differ
         self,
         data: dataset.PredictiveDataset,

--- a/src/tempor/plugins/time_to_event/__init__.py
+++ b/src/tempor/plugins/time_to_event/__init__.py
@@ -25,7 +25,7 @@ class BaseTimeToEventAnalysis(plugins.BasePredictor):
         super().fit(data, *args, **kwargs)
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(  # type: ignore[override]  # pylint: disable=arguments-differ
         self,
         data: dataset.PredictiveDataset,

--- a/src/tempor/plugins/treatments/one_off/_base.py
+++ b/src/tempor/plugins/treatments/one_off/_base.py
@@ -25,7 +25,7 @@ class BaseOneOffTreatmentEffects(plugins.BasePredictor):
         super().fit(data, *args, **kwargs)
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(
         self,
         data: dataset.PredictiveDataset,
@@ -39,7 +39,7 @@ class BaseOneOffTreatmentEffects(plugins.BasePredictor):
     def _predict(self, data: dataset.PredictiveDataset, *args, **kwargs) -> samples.StaticSamples:  # pragma: no cover
         ...
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict_counterfactuals(
         self,
         data: dataset.PredictiveDataset,

--- a/src/tempor/plugins/treatments/temporal/_base.py
+++ b/src/tempor/plugins/treatments/temporal/_base.py
@@ -25,7 +25,7 @@ class BaseTemporalTreatmentEffects(plugins.BasePredictor):
         super().fit(data, *args, **kwargs)
         return self
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict(
         self,
         data: dataset.PredictiveDataset,
@@ -41,7 +41,7 @@ class BaseTemporalTreatmentEffects(plugins.BasePredictor):
     ) -> samples.TimeSeriesSamples:  # pragma: no cover
         ...
 
-    @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
+    @pydantic.validate_arguments(config=pydantic.ConfigDict(arbitrary_types_allowed=True))  # type: ignore [operator]
     def predict_counterfactuals(
         self,
         data: dataset.PredictiveDataset,

--- a/tests/automl/test_pipeline_selector.py
+++ b/tests/automl/test_pipeline_selector.py
@@ -185,6 +185,8 @@ def assert_actual_params(pipe, sample, method):
         assert getattr(estimator.params, k) == v
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("task_type,predictor", TEST_PREDICTOR_CASES)
 @pytest.mark.parametrize("static_imputers", TEST_STATIC_IMPUTERS_CASES)
 @pytest.mark.parametrize("static_scalers", TEST_STATIC_SCALERS_CASES)

--- a/tests/plugins/core/test_base_estimator.py
+++ b/tests/plugins/core/test_base_estimator.py
@@ -135,7 +135,7 @@ class TestBaseEstimator:
             def _fit(self, data, *args, **kwargs):
                 pass
 
-        with pytest.raises(ValueError, match=".*not.*float.*"):
+        with pytest.raises(ValueError, match=".*not.*float.*|valid.*number"):
             _ = MyModel(foo="string")
 
     def test_repr(self):

--- a/tests/plugins/preprocessing/imputation/static/test_static_tabular_imputer.py
+++ b/tests/plugins/preprocessing/imputation/static/test_static_tabular_imputer.py
@@ -31,6 +31,8 @@ def get_test_plugin(get_plugin: Callable):
     return func
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
     test_plugin = get_test_plugin(plugin_from, INIT_KWARGS)
@@ -39,6 +41,8 @@ def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
     assert len(test_plugin.hyperparameter_space()) == 1
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 def test_fit(plugin_from: str, data: str, get_test_plugin: Callable, get_dataset: Callable) -> None:
@@ -52,6 +56,8 @@ def test_fit(plugin_from: str, data: str, get_test_plugin: Callable, get_dataset
     test_plugin.fit(dataset)
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 @pytest.mark.parametrize(
@@ -91,6 +97,8 @@ def test_transform(
     assert output.static.dataframe().isna().sum().sum() == 0
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.filterwarnings("ignore:.*nonzero.*0d.*:DeprecationWarning")  # Expected for EM imputer.
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")  # Expected for EM imputer.
 @pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")  # May happen in some cases.

--- a/tests/plugins/preprocessing/imputation/temporal/test_ts_tabular_imputer.py
+++ b/tests/plugins/preprocessing/imputation/temporal/test_ts_tabular_imputer.py
@@ -31,6 +31,8 @@ def get_test_plugin(get_plugin: Callable):
     return func
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
     test_plugin = get_test_plugin(plugin_from, INIT_KWARGS)
@@ -39,6 +41,8 @@ def test_sanity(get_test_plugin: Callable, plugin_from: str) -> None:
     assert len(test_plugin.hyperparameter_space()) == 1
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 def test_fit(plugin_from: str, data: str, get_test_plugin: Callable, get_dataset: Callable) -> None:
@@ -48,6 +52,8 @@ def test_fit(plugin_from: str, data: str, get_test_plugin: Callable, get_dataset
     test_plugin.fit(dataset)
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_from", PLUGIN_FROM_OPTIONS)
 @pytest.mark.parametrize("data", TEST_ON_DATASETS)
 @pytest.mark.parametrize(
@@ -84,6 +90,8 @@ def test_transform(
     assert output.time_series.dataframe().isna().sum().sum() == 0
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.filterwarnings("ignore:.*nonzero.*0d.*:DeprecationWarning")  # Expected for EM imputer.
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")  # Expected for EM imputer.
 @pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")  # May happen in some cases.

--- a/tests/plugins/test_all_plugins.py
+++ b/tests/plugins/test_all_plugins.py
@@ -9,13 +9,16 @@ from tempor.plugins.core._base_estimator import EmptyParamsDefinition
 PLUGIN_FQNS = plugin_loader.list_fqns()
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_fqn", PLUGIN_FQNS)
 def test_init_success(plugin_fqn):
     PluginCls = plugin_loader.get_class(plugin_fqn)
     PluginCls()  # Should successfully initialize with all default params.
 
 
-# DeprecationWarning expected for preprocessing.imputation.temporal.ts_tabular_imputer:
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_fqn", PLUGIN_FQNS)
 def test_sample_hyperparameters(plugin_fqn):
     PluginCls = plugin_loader.get_class(plugin_fqn)
@@ -24,6 +27,8 @@ def test_sample_hyperparameters(plugin_fqn):
         PluginCls(**args)
 
 
+@pytest.mark.filterwarnings("ignore:.*validate_arguments.*:DeprecationWarning")  # Exp pydantic2 warns from HI.
+@pytest.mark.filterwarnings("ignore:.*conflict.*:UserWarning")  # Exp pydantic2 warns from HI.
 @pytest.mark.parametrize("plugin_fqn", PLUGIN_FQNS)
 def test_repr(plugin_fqn):
     PluginCls = plugin_loader.get_class(plugin_fqn)


### PR DESCRIPTION
## Description
Make changes for pydantic 2, require pydantic >= 2.

## Affected Dependencies
- pydantic >= 2
- in `.pre-commit-config.yaml`, `mypy` section `additional_dependencies: [pydantic>=2]`

## How has this been tested?
- No new tests.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [X] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
