### PR TITLE
Fix#105:  plugin_crn_regressor.py - pass kwargs on fit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
       "hydra-core >=1.3",
       "hyperimpute >= 0.1.17",
       "loguru",
+      "pandas >= 1",
       "pandera >= 0.17.0",
       "pydantic >= 2",
       "torch",

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,8 @@
 # Contributors
 
+## Authors
 * Evgeny Saveliev [e.s.saveliev@gmail.com](mailto:e.s.saveliev@gmail.com)
 * Bogdan Cebere [bogdan.cebere@gmail.com](mailto:bogdan.cebere@gmail.com)
+
+## Community Contributors
+* Julian Klug [@JulianKlug](https://github.com/JulianKlug)

--- a/src/tempor/methods/prediction/temporal/classification/plugin_seq2seq_classifier.py
+++ b/src/tempor/methods/prediction/temporal/classification/plugin_seq2seq_classifier.py
@@ -66,7 +66,7 @@ class Seq2seqClassifier(BaseTemporalClassifier):
         **kwargs: Any,
     ) -> Self:
         cl_dataset = tempor_dataset_to_clairvoyance2_dataset(data)
-        self.model.fit(cl_dataset)
+        self.model.fit(cl_dataset, **kwargs)
         return self
 
     def _predict(

--- a/src/tempor/methods/prediction/temporal/regression/plugin_seq2seq_regressor.py
+++ b/src/tempor/methods/prediction/temporal/regression/plugin_seq2seq_regressor.py
@@ -66,7 +66,7 @@ class Seq2seqRegressor(BaseTemporalRegressor):
         **kwargs: Any,
     ) -> Self:
         cl_dataset = tempor_dataset_to_clairvoyance2_dataset(data)
-        self.model.fit(cl_dataset)
+        self.model.fit(cl_dataset, **kwargs)
         return self
 
     def _predict(

--- a/src/tempor/methods/treatments/temporal/classification/plugin_crn_classifier.py
+++ b/src/tempor/methods/treatments/temporal/classification/plugin_crn_classifier.py
@@ -60,7 +60,7 @@ class CRNTreatmentsClassifier(BaseTemporalTreatmentEffects):
             params=self.params,  # pyright: ignore
         )
 
-        self.model.fit(cl_dataset)
+        self.model.fit(cl_dataset, **kwargs)
         return self
 
     def _predict(  # pylint: disable=arguments-differ

--- a/src/tempor/methods/treatments/temporal/regression/plugin_crn_regressor.py
+++ b/src/tempor/methods/treatments/temporal/regression/plugin_crn_regressor.py
@@ -64,7 +64,7 @@ class CRNTreatmentsRegressor(BaseTemporalTreatmentEffects):
             params=self.params,  # pyright: ignore
         )
 
-        self.model.fit(cl_dataset)
+        self.model.fit(cl_dataset, **kwargs)
         return self
 
     def _predict(  # pylint: disable=arguments-differ


### PR DESCRIPTION
Fit CRN Regressor: pass kwargs on to Clairvoyance CRN fit

## Description
Pass kwargs to self.model.fit to allow passing of device

## Example
<img width="1127" alt="image" src="https://github.com/vanderschaarlab/temporai/assets/8020367/7eb0e790-6264-469e-a7b3-0a540754a589">

fix #105
